### PR TITLE
Prevent cleanup of built package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ deploy:
   on:
     tags: true
     condition: "$TRAVIS_PYTHON_VERSION == 3.6"
+  skip_cleanup: true
   before_deploy: python translate_templates.py
   username: bbp.opensource
   password:


### PR DESCRIPTION
Since travis cleans up the repository directory before deployment, we need to prevent this otherwise the sdist will be broken.