### PR TITLE
Remove sphinx version from regression tests

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -67,7 +67,8 @@ def setup(app):
     def override_regression_test_version(app, pagename, templatename, context, doctree):
         """Override the version of regression test pages to prevent failure during a new release."""
         if pagename in REGRESSION_TEST_PAGENAMES:
-            context["version"] = "regression"
+            context["version"] = "REGRESSION-TEST"
+            context["sphinx_version"] = "REGRESSION-TEST"
 
     # pylint: disable=unused-argument
     def override_with_rtd_version(app, pagename, templatename, context, doctree):

--- a/tests/data/regression.html
+++ b/tests/data/regression.html
@@ -36,11 +36,11 @@
         <meta name="lang:search.tokenizer" content="[\s]+">
       
       <link rel="shortcut icon" href="_static/favicon.ico">
-      <meta name="generator" content="mkdocs-3.1.1, mkdocs-material-4.4.2">
+      <meta name="generator" content="mkdocs-REGRESSION-TEST, mkdocs-material-4.4.2">
     
 
 <!-- Generator banner -->
-<meta name="generator" content="sphinx-3.1.1" />
+<meta name="generator" content="sphinx-REGRESSION-TEST" />
 
     
       
@@ -136,7 +136,7 @@
             <span class="md-header-nav__prefix">
             Blue Brain</span> &ndash;
             Sphinx BlueBrain Theme<span class="md-header-nav__version">
-            regression</span></a>
+            REGRESSION-TEST</span></a>
           </span>
           <span class="md-header-nav__topic">
             <a href="" title="Sample">
@@ -144,7 +144,7 @@
             Blue Brain</span> &ndash;
             Sphinx BlueBrain Theme &ndash;
             Sample<span class="md-header-nav__version">
-            regression</span></a>
+            REGRESSION-TEST</span></a>
           </span>
         
         
@@ -1421,7 +1421,7 @@ Embed an image with optional alignment.
 
       <script src="_static/javascripts/application.718059d6.js"></script>
       
-      <script>app.initialize({version:"3.1.1",url:{base:"./_static"}})</script>
+      <script>app.initialize({version:"REGRESSION-TEST",url:{base:"./_static"}})</script>
       
     
 


### PR DESCRIPTION
This was causing noisy diffs for unrelated changes due to the sphinx version being included in the regression html.