### PR TITLE
Fix version on Read the Docs

### DIFF
--- a/doc/requirements_rtd.txt
+++ b/doc/requirements_rtd.txt
@@ -1,1 +1,2 @@
+setuptools_scm
 sphinx-bluebrain-theme

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,7 +12,6 @@
 
 import os
 from pkg_resources import get_distribution
-from setuptools_scm import get_version
 
 # these pages will have the version overwritten so that it doesn't fail
 # when a new version is released.
@@ -26,6 +25,8 @@ project = u"sphinx-bluebrain-theme"
 # for the documentation build so the version number will be wrong
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:
+    # note: delay import so we only need setuptools_scm on Read the Docs
+    from setuptools_scm import get_version
     version = get_version(root="../..", relative_to=__file__)
 else:
     version = get_distribution("sphinx-bluebrain-theme").version

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -23,10 +23,11 @@ project = u"sphinx-bluebrain-theme"
 
 # read the docs does not like using the cloned repo as the theme
 # for the documentation build so the version number will be wrong
-on_rtd = os.environ.get('READTHEDOCS') == 'True'
+on_rtd = os.environ.get("READTHEDOCS") == "True"
 if on_rtd:
     # note: delay import so we only need setuptools_scm on Read the Docs
-    from setuptools_scm import get_version
+    from setuptools_scm import get_version  # pylint: disable=import-error
+
     version = get_version(root="../..", relative_to=__file__)
 else:
     version = get_distribution("sphinx-bluebrain-theme").version

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,7 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
+import os
 from pkg_resources import get_distribution
+from setuptools_scm import get_version
 
 # these pages will have the version overwritten so that it doesn't fail
 # when a new version is released.
@@ -19,7 +21,15 @@ REGRESSION_TEST_PAGENAMES = {"regression"}
 # -- Project information -----------------------------------------------------
 
 project = u"sphinx-bluebrain-theme"
-version = get_distribution("sphinx-bluebrain-theme").version
+
+# read the docs does not like using the cloned repo as the theme
+# for the documentation build so the version number will be wrong
+on_rtd = os.environ.get('READTHEDOCS') == 'True'
+if on_rtd:
+    version = get_version(root="../..", relative_to=__file__)
+else:
+    version = get_distribution("sphinx-bluebrain-theme").version
+
 release = version
 
 # -- General configuration ---------------------------------------------------
@@ -70,17 +80,7 @@ def setup(app):
             context["version"] = "REGRESSION-TEST"
             context["sphinx_version"] = "REGRESSION-TEST"
 
-    # pylint: disable=unused-argument
-    def override_with_rtd_version(app, pagename, templatename, context, doctree):
-        """Override the version on readthedocs.
-
-        Readthedocs places the version in an injected box, so we can remove it.
-        """
-        if context.get("READTHEDOCS", False):
-            context["version"] = context["current_version"]
-
     # add custom stylesheet
     app.add_css_file("custom.css")
 
     app.connect("html-page-context", override_regression_test_version)
-    app.connect("html-page-context", override_with_rtd_version)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -28,7 +28,9 @@ if on_rtd:
     # note: delay import so we only need setuptools_scm on Read the Docs
     from setuptools_scm import get_version  # pylint: disable=import-error
 
-    version = get_version(root="../..", relative_to=__file__)
+    version = get_version(
+        root="../..", relative_to=__file__, local_scheme="no-local-version"
+    )
 else:
     version = get_distribution("sphinx-bluebrain-theme").version
 


### PR DESCRIPTION
Due to read the docs not being able to use the cloned repo as the theme for building the documentation, we need to install it from pip. Unfortunately, this means the normal method of getting the version will return the wrong value. This PR adds an alternative method which is used only on Read the Docs to correct this.