### PR TITLE
Fix error in contributors when using package.json

### DIFF
--- a/src/utils/metadata.py
+++ b/src/utils/metadata.py
@@ -76,7 +76,7 @@ def get_metadata_from_json(json_path):
 
     # contributors is a special case where they might be
     # specified in the conf.py so don't raise an error
-    output["contributors"] = ",".join(metadata.get("contributors", None))
+    output["contributors"] = ",".join(metadata.get("contributors", ""))
 
     return output
 

--- a/src/utils/metadata.py
+++ b/src/utils/metadata.py
@@ -76,7 +76,7 @@ def get_metadata_from_json(json_path):
 
     # contributors is a special case where they might be
     # specified in the conf.py so don't raise an error
-    output["contributors"] = metadata.get("contributors", None)
+    output["contributors"] = ",".join(metadata.get("contributors", None))
 
     return output
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -93,8 +93,8 @@ def test_get_metadata_from_json():
         # get the metadata
         md = metadata.get_metadata_from_json(fd.name)
 
-        # check contributors is None
-        nt.assert_is_none(md["contributors"])
+        # check contributors is blank
+        nt.eq_(md["contributors"], "")
         del md["contributors"]
 
         # check all values are the same as their keys


### PR DESCRIPTION
When using a package.json file, contributors will
be a list. We need to join this into a comma separated
string.