### PR TITLE
fix: don't use ligatures in code snippets

### DIFF
--- a/src/assets/stylesheets/theme.css_t
+++ b/src/assets/stylesheets/theme.css_t
@@ -520,6 +520,10 @@ body, input {
 pre, code, kbd {
   font-family: Courier, monospace;
 }
+/* if a monospace family font has ligatures, don't use them in code snippets */
+pre, code {
+  font-variant-ligatures: none;
+}
 h1, h2, h3, h4, h5, h6, .md-header-nav__title, .md-footer-copyright__company, .md-hero__inner {
   font-family: "Titillium Web", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }


### PR DESCRIPTION
When courier is not installed, another font with ligatures may be
substituted. We should deactivate ligatures for better readability.

Example with the "stock" package:
![image](https://user-images.githubusercontent.com/2151261/128320848-01403f03-64bd-46b9-a2dd-456de8b9121f.png)
(note the ligature for `fi` in the first line and at the bottom)

Compared to the proposed fix:
![image](https://user-images.githubusercontent.com/2151261/128320938-d275b671-f85c-4ded-a5e5-e7e14302351e.png)

Fixes #36