### PR TITLE
Can disable the check of metadata and conf.py versions

### DIFF
--- a/src/utils/metadata.py
+++ b/src/utils/metadata.py
@@ -240,9 +240,13 @@ def write_metadata_sphinx(app, exception):  # pylint: disable=unused-argument
     # confirm that versions match between metadata and sphinx
     # if using a distribution for metadata, it will catch the case
     # that another version of the same package has been imported
-    assert (
-        metadata["version"] == app.config["version"]
-    ), "conf.py version and metadata version do not match"
+    if os.environ.get("SPHINX_BLUE_BRAIN_THEME_CHECK_VERSIONS", "True").lower() in ["true", "1"]:
+        assert (
+            metadata["version"] == app.config["version"]
+        ), (
+            f"conf.py version ({app.config['version']}) and metadata version "
+            f"({metadata['version']}) do not match"
+        )
 
     contributors = metadata.get("contributors", None)
 


### PR DESCRIPTION
Hello,
Because of this issue in RTD: https://github.com/readthedocs/readthedocs.org/issues/8201, it would be nice to be able to disable the version check in this theme. This is the feature this PR adds.