### PR TITLE
Move classifier in metadata section

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,16 @@ project_urls =
     Source = https://github.com/BlueBrain/sphinx-bluebrain-theme
 license = MIT License
 license_file = LICENSE.txt
+classifiers =
+    Development Status :: 4 - Beta
+    Framework :: Sphinx :: Theme
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Topic :: Documentation :: Sphinx
+    Topic :: Software Development :: Documentation
 
 [options]
 python_requires = >=3.6
@@ -24,16 +34,6 @@ install_requires =
     Jinja2~=3.0.0
 packages = find:
 include_package_data = True
-classifiers =
-    Development Status :: 4 - Beta
-    Framework :: Sphinx :: Theme
-    License :: OSI Approved :: MIT License
-    Operating System :: OS Independent
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Topic :: Documentation :: Sphinx
-    Topic :: Software Development :: Documentation
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Classifiers are not recognized because they are not in the proper section.