### PR TITLE
Fix author with TOML when email is also given

### DIFF
--- a/src/utils/metadata.py
+++ b/src/utils/metadata.py
@@ -101,13 +101,17 @@ def build_metadata_from_setuptools_dict(metadata):
         homepage_url = metadata["url"]
     else:
         homepage_url = project_urls["Homepage"]
+    if "author" in metadata:
+        author = metadata["author"]
+    else:
+        author = metadata["author-email"]
     output = {
         "name": metadata["name"],
         "version": metadata["version"],
         "description": metadata["description"],
         "homepage": homepage_url,
         "license": metadata["license"],
-        "maintainers": metadata["author"],
+        "maintainers": author,
         "repository": repo_url,
         "issuesurl": project_urls["Tracker"],
     }


### PR DESCRIPTION
After some more tests I discovered that the `author` entry in metadata is renamed into `author-email` when both the name and email are given in TOML (see https://peps.python.org/pep-0621/#authors-maintainers). I think this is the last surprise :)