### PR TITLE
Fix creation of empty search_index.json

### DIFF
--- a/.github/workflows/publish-pkg.yml
+++ b/.github/workflows/publish-pkg.yml
@@ -13,10 +13,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools

--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.4.2
+-----
+- |fixed| Fix creation of empty search_index.json
+
 0.3.0
 -----
 

--- a/ci/check-regressions.py
+++ b/ci/check-regressions.py
@@ -29,7 +29,6 @@ def diff_contents():
     Note: We have to do this manually so we can ignore certain changes, like
     the cache busting appends that are done for static files
     """
-
     pattern = re.compile(r"\?v=[0-9A-Fa-f]*")
 
     expected = Path("tests/data/regression.html")

--- a/ci/check-regressions.py
+++ b/ci/check-regressions.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+"""Check for regresssions of building simple docs."""
+
+import json
+from pathlib import Path
+import sys
+
+
+def check_empty_search_index_json():
+    """Ibid."""
+    path = Path("doc/build/html/_static/search/search_index.json")
+    if not path.exists():
+        print(f"{path} does not exist")
+        return False
+    with path.open(encoding="utf8") as fd:
+        try:
+            json.load(fd)
+        except json.JSONDecodeError:
+            print(f"Could not decode json for {path}")
+            raise
+    return True
+
+
+def diff_contents():
+    """Check the contents to see if they match.
+
+    Note: We have to do this manually so we can ignore certain changes, like
+    the cache busting appends that are done for static files
+    """
+
+    def find_differing_offset(l0, l1):
+        for i in range(min(len(l0), len(l1))):
+            if l0[i] != l1[i]:
+                return i
+        assert False, "Should never get here"
+
+    expected = Path("tests/data/regression.html")
+    new = Path("doc/build/html/regression.html")
+
+    with expected.open(encoding="utf8") as fd:
+        expected_lines = fd.readlines()
+
+    with new.open(encoding="utf8") as fd:
+        new_lines = fd.readlines()
+
+    for i, (expected_line, new_line) in enumerate(zip(expected_lines, new_lines)):
+        expected_line, new_line = expected_line.strip(), new_line.strip()
+        if expected_line == new_line:
+            continue
+
+        start = find_differing_offset(expected_line, new_line)
+        quote = new_line[start:].find('"')
+        if quote != -1 and int(new_line[start : start + quote], 16):
+            continue
+
+        print(f"on line {i}, `{expected_line}` != `{new_line}`")
+        return False
+
+    return True
+
+
+if __name__ == "__main__":
+    ret = True
+    for fn in (
+        check_empty_search_index_json,
+        diff_contents,
+    ):
+        ret = fn() and ret
+    if not ret:
+        sys.exit(-1)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,8 +10,8 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
+import importlib.metadata
 import os
-from pkg_resources import get_distribution
 
 # these pages will have the version overwritten so that it doesn't fail
 # when a new version is released.
@@ -32,7 +32,7 @@ if on_rtd:
         root="../..", relative_to=__file__, local_scheme="no-local-version"
     )
 else:
-    version = get_distribution("sphinx-bluebrain-theme").version
+    version = importlib.metadata.version("sphinx-bluebrain-theme")
 
 release = version
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,9 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Documentation :: Sphinx
     Topic :: Software Development :: Documentation
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -26,13 +27,14 @@ classifiers =
     Topic :: Software Development :: Documentation
 
 [options]
-python_requires = >=3.9
+python_requires = >=3.8
 setup_requires =
     setuptools
     setuptools_scm
 install_requires =
     sphinx>=v3.4.0
     Jinja2~=3.0.0
+    importlib-resources; python_version == "3.8"
 packages = find:
 include_package_data = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ classifiers =
     Topic :: Software Development :: Documentation
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.9
 setup_requires =
     setuptools
     setuptools_scm

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,4 @@
 """sphinx_bluebrain_theme package."""
-
 from os import path
 
 from sphinx_bluebrain_theme import utils
@@ -16,3 +15,4 @@ def setup(app):
     app.connect("env-updated", utils.write_metadata_sphinx)
     app.connect("html-page-context", utils.build_tocs)
     app.connect("html-page-context", utils.inject_context_variables)
+    app.connect('build-finished', utils.copy_search_index_json)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -15,4 +15,4 @@ def setup(app):
     app.connect("env-updated", utils.write_metadata_sphinx)
     app.connect("html-page-context", utils.build_tocs)
     app.connect("html-page-context", utils.inject_context_variables)
-    app.connect('build-finished', utils.copy_search_index_json)
+    app.connect("build-finished", utils.copy_search_index_json)

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -5,3 +5,4 @@ from sphinx_bluebrain_theme.utils.inject_context import inject_context_variables
 from sphinx_bluebrain_theme.utils.filters import add_filters
 from sphinx_bluebrain_theme.utils.autodoc_override import add_autodoc_override
 from sphinx_bluebrain_theme.utils.metadata import write_metadata, write_metadata_sphinx
+from sphinx_bluebrain_theme.utils.search_builder import copy_search_index_json

--- a/src/utils/search_builder.py
+++ b/src/utils/search_builder.py
@@ -129,8 +129,10 @@ class SearchIndexBuilder(HTMLParser):
 
 def copy_search_index_json(app, exc):
     """Create and copy the search_index.json file."""
-    if app.builder.format == 'html' and not exc:
-        output = os.path.join(app.builder.outdir, '_static/search')
-        path = importlib.resources.files('sphinx_bluebrain_theme')
-        with importlib.resources.as_file(path / 'static/search/search_index.json_t') as file_:
+    if app.builder.format == "html" and not exc:
+        output = os.path.join(app.builder.outdir, "_static/search")
+        path = importlib.resources.files("sphinx_bluebrain_theme")
+        with importlib.resources.as_file(
+            path / "static/search/search_index.json_t"
+        ) as file_:
             copy_asset_file(str(file_), output, context=app.builder.globalcontext)

--- a/src/utils/search_builder.py
+++ b/src/utils/search_builder.py
@@ -6,9 +6,14 @@ approach used by mkdocs to generate it
 """
 
 import json
-import importlib.resources
 import os
 import re
+
+try:
+    from importlib.resources import files, as_file
+except ImportError:
+    # backport for python 3.8
+    from importlib_resources import files, as_file
 
 from html.parser import HTMLParser
 from sphinx.util.fileutil import copy_asset_file
@@ -131,8 +136,6 @@ def copy_search_index_json(app, exc):
     """Create and copy the search_index.json file."""
     if app.builder.format == "html" and not exc:
         output = os.path.join(app.builder.outdir, "_static/search")
-        path = importlib.resources.files("sphinx_bluebrain_theme")
-        with importlib.resources.as_file(
-            path / "static/search/search_index.json_t"
-        ) as file_:
+        path = files("sphinx_bluebrain_theme")
+        with as_file(path / "static/search/search_index.json_t") as file_:
             copy_asset_file(str(file_), output, context=app.builder.globalcontext)

--- a/src/utils/search_builder.py
+++ b/src/utils/search_builder.py
@@ -5,13 +5,13 @@ which shows the expected structure of the JSON search index and the
 approach used by mkdocs to generate it
 """
 
+import json
+import importlib
+import os
 import re
-from json import dumps
 
-try:
-    from html.parser import HTMLParser
-except ImportError:
-    from HTMLParser import HTMLParser
+from html.parser import HTMLParser
+from sphinx.util.fileutil import copy_asset_file
 
 
 class IndexEntry:
@@ -82,7 +82,7 @@ class SearchIndexBuilder(HTMLParser):
 
         The dumped json is used for the search index build.
         """
-        return dumps(
+        return json.dumps(
             {"docs": [e.as_dict() for e in self._entries], "config": {}}, sort_keys=True
         )
 
@@ -125,3 +125,12 @@ class SearchIndexBuilder(HTMLParser):
             self._current_section.title = data
         elif self._current_section is not None:
             self._current_section.text_list.append(data)
+
+
+def copy_search_index_json(app, exc):
+    """Create and copy the search_index.json file."""
+    if app.builder.format == 'html' and not exc:
+        output = os.path.join(app.builder.outdir, '_static/search')
+        path = importlib.resources.files('sphinx_bluebrain_theme')
+        with importlib.resources.as_file(path / 'static/search/search_index.json_t') as file_:
+            copy_asset_file(str(file_), output, context=app.builder.globalcontext)

--- a/src/utils/search_builder.py
+++ b/src/utils/search_builder.py
@@ -6,7 +6,7 @@ approach used by mkdocs to generate it
 """
 
 import json
-import importlib
+import importlib.resources
 import os
 import re
 

--- a/tests/data/regression.html
+++ b/tests/data/regression.html
@@ -38,7 +38,7 @@
       <link rel="shortcut icon" href="">
       <meta name="generator" content="mkdocs-REGRESSION-TEST, mkdocs-material-4.4.2">
     
-<meta name="generator" content="Docutils 0.19: https://docutils.sourceforge.io/" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <!-- Generator banner -->
 <meta name="generator" content="sphinx-REGRESSION-TEST" />
@@ -61,8 +61,8 @@
       
     
 
-    <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
-    <link rel="stylesheet" type="text/css" href="_static/stylesheets/theme.css" />
+    <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=8e8a900e" />
+    <link rel="stylesheet" type="text/css" href="_static/stylesheets/theme.css?v=eb4d0b14" />
 
     
       <script src="_static/javascripts/modernizr.74668098.js"></script>
@@ -1428,9 +1428,9 @@ Embed an image with optional alignment.
       
     </div>
     
-    <script data-url_root="./" id="documentation_options" src="_static/documentation_options.js"></script>
-    <script src="_static/doctools.js"></script>
-    <script src="_static/sphinx_highlight.js"></script>
+    <script data-url_root="./" id="documentation_options" src="_static/documentation_options.js?v=21ccd5af"></script>
+    <script src="_static/doctools.js?v=888ff710"></script>
+    <script src="_static/sphinx_highlight.js?v=4825356b"></script>
 <script src="https://code.jquery.com/jquery-3.6.3.slim.min.js"></script>
 <script src="_static/javascripts/theme.js"></script>
 <script src="_static/javascripts/utils.js"></script>

--- a/tests/data/regression.html
+++ b/tests/data/regression.html
@@ -1430,7 +1430,7 @@ Embed an image with optional alignment.
     
     <script data-url_root="./" id="documentation_options" src="_static/documentation_options.js?v=21ccd5af"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
-    <script src="_static/sphinx_highlight.js?v=4825356b"></script>
+    <script src="_static/sphinx_highlight.js?v=1"></script>
 <script src="https://code.jquery.com/jquery-3.6.3.slim.min.js"></script>
 <script src="_static/javascripts/theme.js"></script>
 <script src="_static/javascripts/utils.js"></script>

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,12 @@ build_docs =
 allowlist_externals =
     make
 black_version = 22.0
+paths_to_lint =
+    sphinx_bluebrain_theme \
+    mkdocs2sphinx \
+    translate_templates.py \
+    setup.py \
+    tests
 
 [tox]
 minversion = 3.20
@@ -32,7 +38,6 @@ commands_pre =
 commands =
     pytest tests
     {[base]build_docs}
-    bash -ec 'P=./doc/build/html/_static/search/search_index.json && if ! [[ -s $P ]]; then echo "**** $P is empty ****"; pwd; false; fi'
     git --no-pager diff --no-index -- tests/data/regression.html doc/build/html/regression.html
 allowlist_externals =
     bash
@@ -48,22 +53,12 @@ deps =
     black~={[base]black_version}
     sphinx
 commands =
-    pycodestyle sphinx_bluebrain_theme
-    pydocstyle sphinx_bluebrain_theme
-    pylint sphinx_bluebrain_theme
-    pycodestyle mkdocs2sphinx
-    pydocstyle mkdocs2sphinx
-    pylint mkdocs2sphinx
-    pycodestyle translate_templates.py
-    pydocstyle translate_templates.py
-    pylint translate_templates.py
-    pycodestyle setup.py
-    pydocstyle setup.py
-    pylint setup.py
-    pycodestyle tests
-    pydocstyle tests
-    pylint tests
+    pycodestyle {[base]paths_to_lint}
+    pydocstyle {[base]paths_to_lint}
+    pylint {[base]paths_to_lint}
+
     pylint doc/source/conf.py
+
     black . --check -v
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ envlist =
     py{38,39,310}
 
 [testenv]
-basepython = python3.8
 # we skip the install initially so as to build an up-to-date version
 skip_install = true
 deps =
@@ -33,8 +32,10 @@ commands_pre =
 commands =
     pytest tests
     {[base]build_docs}
+    bash -ec 'P=./doc/build/html/_static/search/search_index.json && if ! [[ -s $P ]]; then echo "**** $P is empty ****"; pwd; false; fi'
     git --no-pager diff --no-index -- tests/data/regression.html doc/build/html/regression.html
 allowlist_externals =
+    bash
     git
     make
 
@@ -93,6 +94,6 @@ commands = black . -v
 
 [gh-actions]
 python =
-  3.8: py38, lint, docs, check-packaging
   3.9: py39
   3.10: py310
+  3.11: py311, lint, docs, check-packaging

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,12 @@ allowlist_externals =
     make
 black_version = 22.0
 paths_to_lint =
-    sphinx_bluebrain_theme \
+    ci/check-regressions.py \
     mkdocs2sphinx \
-    translate_templates.py \
     setup.py \
-    tests
+    sphinx_bluebrain_theme \
+    tests \
+    translate_templates.py
 
 [tox]
 minversion = 3.20
@@ -38,11 +39,10 @@ commands_pre =
 commands =
     pytest tests
     {[base]build_docs}
-    git --no-pager diff --no-index -- tests/data/regression.html doc/build/html/regression.html
+    ci/check-regressions.py
 allowlist_externals =
-    bash
-    git
-    make
+    {[base]allowlist_externals}
+    ci/check-regressions.py
 
 [testenv:lint]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -39,10 +39,9 @@ commands_pre =
 commands =
     pytest tests
     {[base]build_docs}
-    ci/check-regressions.py
+    python ci/check-regressions.py
 allowlist_externals =
     {[base]allowlist_externals}
-    ci/check-regressions.py
 
 [testenv:lint]
 deps =
@@ -55,10 +54,7 @@ deps =
 commands =
     pycodestyle {[base]paths_to_lint}
     pydocstyle {[base]paths_to_lint}
-    pylint {[base]paths_to_lint}
-
-    pylint doc/source/conf.py
-
+    pylint {[base]paths_to_lint} doc/source/conf.py
     black . --check -v
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,7 @@ commands = black . -v
 
 [gh-actions]
 python =
+  3.8: py38
   3.9: py39
   3.10: py310
   3.11: py311, lint, docs, check-packaging

--- a/translate_templates.py
+++ b/translate_templates.py
@@ -1,8 +1,7 @@
 """This module will translate the mkdocs material theme to a Sphinx theme."""
 
+import shutil
 from pathlib import Path
-
-from distutils import dir_util  # pylint: disable= no-name-in-module
 
 from mkdocs2sphinx import copy_source, convert_files
 
@@ -17,7 +16,6 @@ def _ignore_on_copy(directory, contents):  # pylint: disable=unused-argument
     Returns:
         list: A list of files to be ignored.
     """
-    # shutil passes strings, so ensure a Path
     directory = Path(directory)
     if directory.name == "material":
         return ["mkdocs_theme.yml", "main.html", "404.html"]
@@ -68,10 +66,7 @@ if __name__ == "__main__":
         end_colour = "\033[0m"
         print(f"{colour}{k}: {v}{end_colour}")
 
-    # copy some additional files into the theme
-    # copy_tree requires strings not paths, we use it here
-    # as it allows directories to be merged (shutil.copytree does not)
-    dir_util.copy_tree(str(PWD_PATH / "src"), str(OUT_PATH))
+    shutil.copytree(PWD_PATH / "src", OUT_PATH, dirs_exist_ok=True)
 
     # sphinx expects a 'static' directory so rename the mkdocs-material one
     (OUT_PATH / "assets").rename(OUT_PATH / "static")


### PR DESCRIPTION
* moved search_index.json creation to 'build_finished' step
  Between 7.0.1 and 7.1.0, the order was changed when 'static' files are created: https://github.com/sphinx- 
  doc/sphinx/pull/11415/files#diff-be839d87d39d93093003a0a4ce40cf9610d0a9445e5e0aeb1cdc6bab527bfbbcL682 So 
  the context doesn't yet contain the dict that is created by: https://github.com/BlueBrain/sphinx-bluebrain- 
  theme/blob/master/src/utils/inject_context.py#L182
* added a test that this file is created, and is not empty
* update tests to sphinx 7.1.2
* add py3.11 to CI