### PR TITLE
Add tests for Python 3.12, replace pkg_resources, update regression.html

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v3
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.4.3
+-----
+- |added| Add tests for Python 3.12
+- |changed| Replace pkg_resources with importlib
+- |fixed| Fix ``regression.html`` with sphinx 7.2
+
 0.4.2
 -----
 - |fixed| Fix creation of empty search_index.json

--- a/ci/check-regressions.py
+++ b/ci/check-regressions.py
@@ -3,9 +3,18 @@
 
 import itertools
 import json
-from pathlib import Path
-import sys
 import re
+import sys
+from pathlib import Path
+
+import sphinx
+
+
+def _get_expected_path():
+    if sphinx.version_info < (7, 2):
+        # sphinx 7.2.0 dropped Python 3.8 support
+        return Path("tests/data/regression_sphinx_7.1.html")
+    return Path("tests/data/regression.html")
 
 
 def check_empty_search_index_json():
@@ -31,7 +40,7 @@ def diff_contents():
     """
     pattern = re.compile(r"\?v=[0-9A-Fa-f]*")
 
-    expected = Path("tests/data/regression.html")
+    expected = _get_expected_path()
     new = Path("doc/build/html/regression.html")
 
     with expected.open(encoding="utf8") as fd:

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ setup_requires =
     setuptools
     setuptools_scm
 install_requires =
-    setuptools
     sphinx>=4.2.0
     Jinja2~=3.0
     importlib-resources; python_version == "3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,8 @@ setup_requires =
 install_requires =
     sphinx>=4.2.0
     Jinja2~=3.0
-    importlib-resources; python_version == "3.8"
+    importlib-metadata; python_full_version < "3.10.2"
+    importlib-resources; python_full_version < "3.10.2"
 packages = find:
 include_package_data = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Documentation :: Sphinx
     Topic :: Software Development :: Documentation
 
@@ -32,6 +33,7 @@ setup_requires =
     setuptools
     setuptools_scm
 install_requires =
+    setuptools
     sphinx>=4.2.0
     Jinja2~=3.0
     importlib-resources; python_version == "3.8"

--- a/src/utils/_importlib.py
+++ b/src/utils/_importlib.py
@@ -1,0 +1,11 @@
+"""Ensure that the right version of importlib is imported."""
+
+# pylint: disable=unused-import
+
+import sys
+
+if sys.version_info >= (3, 10, 2):
+    from importlib import metadata, resources
+else:
+    import importlib_metadata as metadata
+    import importlib_resources as resources

--- a/src/utils/metadata.py
+++ b/src/utils/metadata.py
@@ -124,18 +124,14 @@ def get_metadata_from_distribution(distribution_name):
     """Get the metadata from a distribution."""
     metadata = {}
     # useful information: https://packaging.python.org/specifications/core-metadata/
-    for mdl in importlib.metadata.metadata(distribution_name):
-        # guard against silly data
-        if ":" not in mdl:
-            continue
-
-        key, value = mdl.split(":", 1)
+    md = importlib.metadata.metadata(distribution_name)
+    for key in md:
         key = key.lower()
-        value = value.strip()
+        value = md[key].strip()
 
         # treat UNKNOWN as no value, this the setuptools metadata
         # equivalent of None
-        if value == "UNKNOWN":
+        if not value or value == "UNKNOWN":
             continue
 
         # handle special cases

--- a/src/utils/metadata.py
+++ b/src/utils/metadata.py
@@ -1,19 +1,16 @@
 """Utilities for creating a metadata file."""
+
 import datetime
+import importlib.metadata
 import json
 import os
 import sys
-
 from contextlib import contextmanager
-from subprocess import check_output, CalledProcessError
+from subprocess import CalledProcessError, check_output
 
-import sphinx
-from pkg_resources import get_distribution
-
+import sphinx.util
 
 logger = sphinx.util.logging.getLogger(__name__)
-
-METADATA_NAMES = ("METADATA", "PKG-INFO")
 
 
 @contextmanager
@@ -125,22 +122,9 @@ def build_metadata_from_setuptools_dict(metadata):
 
 def get_metadata_from_distribution(distribution_name):
     """Get the metadata from a distribution."""
-    # useful information: https://packaging.python.org/specifications/core-metadata/
-    dist = get_distribution(distribution_name)
-
     metadata = {}
-
-    # get metadata name or error
-    for mdn in METADATA_NAMES:
-        if dist.has_metadata(mdn):
-            metadata_name = mdn
-            break
-    else:
-        raise FileNotFoundError(
-            f"package has no metadata file with name: {METADATA_NAMES}"
-        )
-
-    for mdl in dist.get_metadata_lines(metadata_name):
+    # useful information: https://packaging.python.org/specifications/core-metadata/
+    for mdl in importlib.metadata.metadata(distribution_name):
         # guard against silly data
         if ":" not in mdl:
             continue

--- a/src/utils/metadata.py
+++ b/src/utils/metadata.py
@@ -1,7 +1,6 @@
 """Utilities for creating a metadata file."""
 
 import datetime
-import importlib.metadata
 import json
 import os
 import sys
@@ -9,6 +8,8 @@ from contextlib import contextmanager
 from subprocess import CalledProcessError, check_output
 
 import sphinx.util
+
+from sphinx_bluebrain_theme.utils._importlib import metadata as importlib_metadata
 
 logger = sphinx.util.logging.getLogger(__name__)
 
@@ -131,7 +132,7 @@ def get_metadata_from_distribution(distribution_name):
     metadata = {}
     # useful information: https://packaging.python.org/specifications/core-metadata/
     # the keys are all lower case and using _ as a separator
-    metadata_json = importlib.metadata.metadata(distribution_name).json
+    metadata_json = importlib_metadata.metadata(distribution_name).json
     for key, value in metadata_json.items():
         # treat UNKNOWN as no value, this the setuptools metadata
         # equivalent of None

--- a/src/utils/search_builder.py
+++ b/src/utils/search_builder.py
@@ -8,15 +8,11 @@ approach used by mkdocs to generate it
 import json
 import os
 import re
-
-try:
-    from importlib.resources import files, as_file
-except ImportError:
-    # backport for python 3.8
-    from importlib_resources import files, as_file
-
 from html.parser import HTMLParser
+
 from sphinx.util.fileutil import copy_asset_file
+
+from sphinx_bluebrain_theme.utils._importlib import resources as importlib_resources
 
 
 class IndexEntry:
@@ -136,6 +132,8 @@ def copy_search_index_json(app, exc):
     """Create and copy the search_index.json file."""
     if app.builder.format == "html" and not exc:
         output = os.path.join(app.builder.outdir, "_static/search")
-        path = files("sphinx_bluebrain_theme")
-        with as_file(path / "static/search/search_index.json_t") as file_:
+        path = importlib_resources.files("sphinx_bluebrain_theme")
+        with importlib_resources.as_file(
+            path / "static/search/search_index.json_t"
+        ) as file_:
             copy_asset_file(str(file_), output, context=app.builder.globalcontext)

--- a/tests/data/regression.html
+++ b/tests/data/regression.html
@@ -679,23 +679,23 @@
                 
                 
                 <section id="sample">
-<h1>Sample<a class="headerlink" href="#sample" title="Permalink to this heading">¶</a></h1>
+<h1>Sample<a class="headerlink" href="#sample" title="Link to this heading">¶</a></h1>
 <p>This page includes samples of the expected output of the theme as well as
 the input used to generate it.</p>
 <section id="second-level-headings">
-<h2>Second level headings<a class="headerlink" href="#second-level-headings" title="Permalink to this heading">¶</a></h2>
+<h2>Second level headings<a class="headerlink" href="#second-level-headings" title="Link to this heading">¶</a></h2>
 <p>Second level heading section content.</p>
 <section id="third-level-headings">
-<h3>Third level headings<a class="headerlink" href="#third-level-headings" title="Permalink to this heading">¶</a></h3>
+<h3>Third level headings<a class="headerlink" href="#third-level-headings" title="Link to this heading">¶</a></h3>
 <p>Third level heading section content.</p>
 <section id="fourth-level-headings">
-<h4>Fourth level headings<a class="headerlink" href="#fourth-level-headings" title="Permalink to this heading">¶</a></h4>
+<h4>Fourth level headings<a class="headerlink" href="#fourth-level-headings" title="Link to this heading">¶</a></h4>
 <p>Fourth level heading section content.</p>
 <section id="fifth-level-headings">
-<h5>Fifth level headings<a class="headerlink" href="#fifth-level-headings" title="Permalink to this heading">¶</a></h5>
+<h5>Fifth level headings<a class="headerlink" href="#fifth-level-headings" title="Link to this heading">¶</a></h5>
 <p>Fifth level heading section content.</p>
 <section id="sixth-level-headings">
-<h6>Sixth level headings<a class="headerlink" href="#sixth-level-headings" title="Permalink to this heading">¶</a></h6>
+<h6>Sixth level headings<a class="headerlink" href="#sixth-level-headings" title="Link to this heading">¶</a></h6>
 <p>Sixth level heading section content.</p>
 <div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Sample</span>
 <span class="gh">======</span>
@@ -735,9 +735,9 @@ Sixth level heading section content.
 </section>
 </section>
 <section id="lists">
-<h2>Lists<a class="headerlink" href="#lists" title="Permalink to this heading">¶</a></h2>
+<h2>Lists<a class="headerlink" href="#lists" title="Link to this heading">¶</a></h2>
 <section id="unordered-lists">
-<h3>Unordered lists<a class="headerlink" href="#unordered-lists" title="Permalink to this heading">¶</a></h3>
+<h3>Unordered lists<a class="headerlink" href="#unordered-lists" title="Link to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>list item 1.</p></li>
 <li><p>list item 2.</p>
@@ -768,7 +768,7 @@ Sixth level heading section content.
 </div>
 </section>
 <section id="ordered-lists">
-<h3>Ordered lists<a class="headerlink" href="#ordered-lists" title="Permalink to this heading">¶</a></h3>
+<h3>Ordered lists<a class="headerlink" href="#ordered-lists" title="Link to this heading">¶</a></h3>
 <ol class="arabic simple">
 <li><p>List item 1.</p></li>
 <li><p>List item 2.</p>
@@ -799,7 +799,7 @@ Sixth level heading section content.
 </div>
 </section>
 <section id="definition-lists">
-<h3>Definition lists<a class="headerlink" href="#definition-lists" title="Permalink to this heading">¶</a></h3>
+<h3>Definition lists<a class="headerlink" href="#definition-lists" title="Link to this heading">¶</a></h3>
 <dl class="simple">
 <dt>Definition list item 1</dt><dd><p>Definition text for definition list item 1.</p>
 </dd>
@@ -819,9 +819,9 @@ Definition list item 2
 </section>
 </section>
 <section id="code">
-<h2>Code<a class="headerlink" href="#code" title="Permalink to this heading">¶</a></h2>
+<h2>Code<a class="headerlink" href="#code" title="Link to this heading">¶</a></h2>
 <section id="inline-code">
-<h3>Inline code<a class="headerlink" href="#inline-code" title="Permalink to this heading">¶</a></h3>
+<h3>Inline code<a class="headerlink" href="#inline-code" title="Link to this heading">¶</a></h3>
 <p>Here is some sample inline code: <code class="code highlight py3 python3 docutils literal highlight-python3"><span class="k">if</span> <span class="n">test</span><span class="p">:</span> <span class="k">return</span> <span class="kc">True</span></code>.</p>
 <div class="admonition attention">
 <p class="admonition-title">Attention</p>
@@ -844,7 +844,7 @@ Here is some sample inline code: <span class="na">:py3:</span><span class="nv">`
 </div>
 </section>
 <section id="code-blocks">
-<h3>Code blocks<a class="headerlink" href="#code-blocks" title="Permalink to this heading">¶</a></h3>
+<h3>Code blocks<a class="headerlink" href="#code-blocks" title="Link to this heading">¶</a></h3>
 <div class="highlight-python3 notranslate"><div class="highlight"><pre><span></span><span class="linenos">1</span><span class="k">def</span> <span class="nf">double</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
 <span class="hll"><span class="linenos">2</span>   <span class="k">return</span> <span class="mi">2</span> <span class="o">*</span> <span class="n">x</span>
 </span></pre></div>
@@ -862,7 +862,7 @@ Here is some sample inline code: <span class="na">:py3:</span><span class="nv">`
 </div>
 </section>
 <section id="code-tabs">
-<h3>Code tabs<a class="headerlink" href="#code-tabs" title="Permalink to this heading">¶</a></h3>
+<h3>Code tabs<a class="headerlink" href="#code-tabs" title="Link to this heading">¶</a></h3>
 <p>Tabs can be used to show multiple examples without excessive space. The code
 can be entered directly or included from a file.</p>
 <div class="superfences-tabs docutils container">
@@ -917,7 +917,7 @@ can be entered directly or included from a file.
 </section>
 </section>
 <section id="tables">
-<h2>Tables<a class="headerlink" href="#tables" title="Permalink to this heading">¶</a></h2>
+<h2>Tables<a class="headerlink" href="#tables" title="Link to this heading">¶</a></h2>
 <table class="docutils align-default">
 <thead>
 <tr class="row-odd"><th class="head"><p>Table header column 1</p></th>
@@ -960,9 +960,9 @@ can be entered directly or included from a file.
 </div>
 </section>
 <section id="admonitions">
-<h2>Admonitions<a class="headerlink" href="#admonitions" title="Permalink to this heading">¶</a></h2>
+<h2>Admonitions<a class="headerlink" href="#admonitions" title="Link to this heading">¶</a></h2>
 <section id="built-in-types">
-<h3>Built-in types<a class="headerlink" href="#built-in-types" title="Permalink to this heading">¶</a></h3>
+<h3>Built-in types<a class="headerlink" href="#built-in-types" title="Link to this heading">¶</a></h3>
 <div class="admonition attention">
 <p class="admonition-title">Attention</p>
 <p>Attention</p>
@@ -1041,7 +1041,7 @@ can be entered directly or included from a file.
 </div>
 </section>
 <section id="additional-types">
-<h3>Additional types<a class="headerlink" href="#additional-types" title="Permalink to this heading">¶</a></h3>
+<h3>Additional types<a class="headerlink" href="#additional-types" title="Link to this heading">¶</a></h3>
 <p>These types require you to add the class explicitly using <code class="docutils literal notranslate"><span class="pre">:class:</span> <span class="pre">classname</span></code>.
 Applicable classnames are shown in each admonition.</p>
 <div class="abstract admonition">
@@ -1177,9 +1177,9 @@ Applicable classnames are shown in each admonition.
 </section>
 </section>
 <section id="miscellaneous">
-<h2>Miscellaneous<a class="headerlink" href="#miscellaneous" title="Permalink to this heading">¶</a></h2>
+<h2>Miscellaneous<a class="headerlink" href="#miscellaneous" title="Link to this heading">¶</a></h2>
 <section id="blockquotes">
-<h3>Blockquotes<a class="headerlink" href="#blockquotes" title="Permalink to this heading">¶</a></h3>
+<h3>Blockquotes<a class="headerlink" href="#blockquotes" title="Link to this heading">¶</a></h3>
 <blockquote>
 <div><p>Blockquote content.</p>
 </div></blockquote>
@@ -1190,7 +1190,7 @@ Applicable classnames are shown in each admonition.
 </pre></div>
 </div>
 <section id="nested-blockquotes">
-<h4>Nested blockquotes<a class="headerlink" href="#nested-blockquotes" title="Permalink to this heading">¶</a></h4>
+<h4>Nested blockquotes<a class="headerlink" href="#nested-blockquotes" title="Link to this heading">¶</a></h4>
 <blockquote>
 <div><p>Blockquote content.</p>
 <blockquote>
@@ -1213,7 +1213,7 @@ Applicable classnames are shown in each admonition.
 </section>
 </section>
 <section id="horizontal-rules">
-<h3>Horizontal rules<a class="headerlink" href="#horizontal-rules" title="Permalink to this heading">¶</a></h3>
+<h3>Horizontal rules<a class="headerlink" href="#horizontal-rules" title="Link to this heading">¶</a></h3>
 <p>Here is some text before a horizontal rule.</p>
 <hr class="docutils" />
 <p>Here is some text after a horizontal rule</p>
@@ -1229,7 +1229,7 @@ Here is some text after a horizontal rule
 </div>
 </section>
 <section id="epigraphs">
-<h3>Epigraphs<a class="headerlink" href="#epigraphs" title="Permalink to this heading">¶</a></h3>
+<h3>Epigraphs<a class="headerlink" href="#epigraphs" title="Link to this heading">¶</a></h3>
 <blockquote class="epigraph">
 <div><p>This is an epigraph.</p>
 <p class="attribution">—by an Author</p>
@@ -1246,7 +1246,7 @@ Here is some text after a horizontal rule
 </div>
 </section>
 <section id="topics">
-<h3>Topics<a class="headerlink" href="#topics" title="Permalink to this heading">¶</a></h3>
+<h3>Topics<a class="headerlink" href="#topics" title="Link to this heading">¶</a></h3>
 <aside class="topic">
 <p class="topic-title">Topic title</p>
 <p>This is a topic</p>
@@ -1261,7 +1261,7 @@ Here is some text after a horizontal rule
 </div>
 </section>
 <section id="sidebars">
-<h3>Sidebars<a class="headerlink" href="#sidebars" title="Permalink to this heading">¶</a></h3>
+<h3>Sidebars<a class="headerlink" href="#sidebars" title="Link to this heading">¶</a></h3>
 <aside class="admonition sidebar">
 <p class="sidebar-title">Sidebar title</p>
 <p>This is a sidebar</p>
@@ -1284,7 +1284,7 @@ sidebar.
 </div>
 </section>
 <section id="collapsible-blocks">
-<h3>Collapsible blocks<a class="headerlink" href="#collapsible-blocks" title="Permalink to this heading">¶</a></h3>
+<h3>Collapsible blocks<a class="headerlink" href="#collapsible-blocks" title="Link to this heading">¶</a></h3>
 <details>
 <summary>Details hidden by default</summary><p>Here is some content that is hidden before opening.</p>
 </details><details open="">
@@ -1304,7 +1304,7 @@ sidebar.
 </div>
 </section>
 <section id="iframes">
-<h3>IFrames<a class="headerlink" href="#iframes" title="Permalink to this heading">¶</a></h3>
+<h3>IFrames<a class="headerlink" href="#iframes" title="Link to this heading">¶</a></h3>
 <p>Embed existing HTML files (such as Doxygen output) in generated pages.</p>
 <iframe class="sphinx-iframe" scrolling="no" src="index.html">
 </iframe><div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">IFrames</span>
@@ -1317,7 +1317,7 @@ Embed existing HTML files (such as Doxygen output) in generated pages.
 </div>
 </section>
 <section id="images">
-<h3>Images<a class="headerlink" href="#images" title="Permalink to this heading">¶</a></h3>
+<h3>Images<a class="headerlink" href="#images" title="Link to this heading">¶</a></h3>
 <p>Embed an image with optional alignment.</p>
 <a class="reference internal image-reference" href="_images/epfl-logo-new.svg"><img alt="_images/epfl-logo-new.svg" class="align-left" src="_images/epfl-logo-new.svg" width="25%" /></a>
 <a class="reference internal image-reference" href="_images/epfl-logo-new.svg"><img alt="_images/epfl-logo-new.svg" class="align-center" src="_images/epfl-logo-new.svg" width="25%" /></a>
@@ -1393,7 +1393,7 @@ Embed an image with optional alignment.
         
         
           <div class="md-footer-copyright__highlight">
-            &copy; Blue Brain Project/EPFL 2005-2023. All rights reserved.
+            &copy; Blue Brain Project/EPFL 2005-2024. All rights reserved.
           </div>
         
         
@@ -1427,8 +1427,8 @@ Embed an image with optional alignment.
 </footer>
       
     </div>
-    
-    <script data-url_root="./" id="documentation_options" src="_static/documentation_options.js?v=21ccd5af"></script>
+
+    <script src="_static/documentation_options.js?v=1c1e9534"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=1"></script>
 <script src="https://code.jquery.com/jquery-3.6.3.slim.min.js"></script>

--- a/tests/data/regression_sphinx_7.1.html
+++ b/tests/data/regression_sphinx_7.1.html
@@ -1,0 +1,1445 @@
+
+
+
+
+
+
+
+<!doctype html>
+<html lang="en" class="no-js">
+  <head>
+
+
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width,initial-scale=1">
+      <meta http-equiv="x-ua-compatible" content="ie=edge">
+
+
+
+
+        <meta name="lang:clipboard.copy" content="Copy to clipboard">
+
+        <meta name="lang:clipboard.copied" content="Copied to clipboard">
+
+        <meta name="lang:search.language" content="en">
+
+        <meta name="lang:search.pipeline.stopwords" content="True">
+
+        <meta name="lang:search.pipeline.trimmer" content="True">
+
+        <meta name="lang:search.result.none" content="No matching documents">
+
+        <meta name="lang:search.result.one" content="1 matching document">
+
+        <meta name="lang:search.result.other" content="# matching documents">
+
+        <meta name="lang:search.tokenizer" content="[\s]+">
+
+      <link rel="shortcut icon" href="">
+      <meta name="generator" content="mkdocs-REGRESSION-TEST, mkdocs-material-4.4.2">
+
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<!-- Generator banner -->
+<meta name="generator" content="sphinx-REGRESSION-TEST" />
+
+
+
+        <title>Sample - Sphinx BlueBrain Theme</title>
+
+
+
+
+      <link rel="stylesheet" href="_static/stylesheets/application.4031d38b.css">
+
+        <link rel="stylesheet" href="_static/stylesheets/application-palette.3e3d1dff.css">
+
+
+
+
+        <meta name="theme-color" content="#2196f3">
+
+
+
+    <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=8e8a900e" />
+    <link rel="stylesheet" type="text/css" href="_static/stylesheets/theme.css?v=eb4d0b14" />
+
+
+      <script src="_static/javascripts/modernizr.74668098.js"></script>
+
+
+
+    <link rel="stylesheet" href="_static/fonts/material-icons.css">
+
+
+
+
+
+  </head>
+
+
+
+    <body dir="ltr" data-md-color-primary="blue" data-md-color-accent="blue">
+
+    <svg class="md-svg">
+      <defs>
+
+
+          <svg xmlns="http://www.w3.org/2000/svg" width="416" height="448" viewBox="0 0 416 448" id="__github"><path fill="currentColor" d="M160 304q0 10-3.125 20.5t-10.75 19T128 352t-18.125-8.5-10.75-19T96 304t3.125-20.5 10.75-19T128 256t18.125 8.5 10.75 19T160 304zm160 0q0 10-3.125 20.5t-10.75 19T288 352t-18.125-8.5-10.75-19T256 304t3.125-20.5 10.75-19T288 256t18.125 8.5 10.75 19T320 304zm40 0q0-30-17.25-51T296 232q-10.25 0-48.75 5.25Q229.5 240 208 240t-39.25-2.75Q130.75 232 120 232q-29.5 0-46.75 21T56 304q0 22 8 38.375t20.25 25.75 30.5 15 35 7.375 37.25 1.75h42q20.5 0 37.25-1.75t35-7.375 30.5-15 20.25-25.75T360 304zm56-44q0 51.75-15.25 82.75-9.5 19.25-26.375 33.25t-35.25 21.5-42.5 11.875-42.875 5.5T212 416q-19.5 0-35.5-.75t-36.875-3.125-38.125-7.5-34.25-12.875T37 371.5t-21.5-28.75Q0 312 0 260q0-59.25 34-99-6.75-20.5-6.75-42.5 0-29 12.75-54.5 27 0 47.5 9.875t47.25 30.875Q171.5 96 212 96q37 0 70 8 26.25-20.5 46.75-30.25T376 64q12.75 25.5 12.75 54.5 0 21.75-6.75 42 34 40 34 99.5z"/></svg>
+
+      </defs>
+    </svg>
+    <input class="md-toggle" data-md-toggle="drawer" type="checkbox" id="__drawer" autocomplete="off">
+    <input class="md-toggle" data-md-toggle="search" type="checkbox" id="__search" autocomplete="off">
+    <label class="md-overlay" data-md-component="overlay" for="__drawer"></label>
+
+      <a href="#second-level-headings" tabindex="1" class="md-skip">
+        Skip to content
+      </a>
+
+
+
+
+<!-- Application header -->
+<header class="md-header" data-md-component="header">
+
+  <!-- Top-level navigation -->
+  <nav class="md-header-nav md-grid">
+    <div class="md-flex">
+
+      <!-- Link to home -->
+      <div class="md-flex__cell md-flex__cell--shrink">
+        <a href="https://www.epfl.ch/"
+            title="Sphinx BlueBrain Theme"
+            class="md-header-nav__button md-logo">
+
+            <img src="_static/images/epfl-logo-new.svg" width="24" height="24" />
+
+        </a>
+      </div>
+
+      <!-- Button to toggle drawer -->
+      <div class="md-flex__cell md-flex__cell--shrink">
+        <label class="md-icon md-icon--menu md-header-nav__button"
+            for="__drawer"></label>
+      </div>
+
+
+      <!-- Home button to ecosystem -->
+      <div class="md-flex__cell md-flex__cell--shrink">
+        <div id="homeBtnContainer" class="documentation-homepage-icon">
+          <!-- this href will be overwritten by utils.js -->
+          <a href="#" id="homepageLink">
+            <i class="fa fa-home"></i>
+          </a>
+        </div>
+      </div>
+
+
+      <!-- Header title -->
+      <div class="md-flex__cell md-flex__cell--stretch">
+        <div class="md-flex__ellipsis md-header-nav__title"
+            data-md-component="title">
+
+
+          <span class="md-header-nav__topic">
+            <a href="index.html"
+                title="Sphinx BlueBrain Theme">
+            <span class="md-header-nav__prefix">
+            Blue Brain</span> &ndash;
+            Sphinx BlueBrain Theme<span class="md-header-nav__version">
+            REGRESSION-TEST</span></a>
+          </span>
+          <span class="md-header-nav__topic">
+            <a href="" title="Sample">
+            <span class="md-header-nav__prefix">
+            Blue Brain</span> &ndash;
+            Sphinx BlueBrain Theme &ndash;
+            Sample<span class="md-header-nav__version">
+            REGRESSION-TEST</span></a>
+          </span>
+
+
+        </div>
+      </div>
+
+      <!-- Button to open search dialogue -->
+      <div class="md-flex__cell md-flex__cell--shrink">
+
+          <label class="md-icon md-icon--search md-header-nav__button"
+              for="__search"></label>
+
+          <!-- Search interface -->
+
+<div class="md-search" data-md-component="search" role="dialog">
+  <label class="md-search__overlay" for="__search"></label>
+  <div class="md-search__inner" role="search">
+    <form class="md-search__form" name="search">
+      <input type="text" class="md-search__input" name="query" placeholder="Search" autocapitalize="off" autocorrect="off" autocomplete="off" spellcheck="false" data-md-component="query" data-md-state="active">
+      <label class="md-icon md-search__icon" for="__search"></label>
+      <button type="reset" class="md-icon md-search__icon" data-md-component="reset" tabindex="-1">
+        &#xE5CD;
+      </button>
+    </form>
+    <div class="md-search__output">
+      <div class="md-search__scrollwrap" data-md-scrollfix>
+        <div class="md-search-result" data-md-component="result">
+          <div class="md-search-result__meta">
+            Type to start searching
+          </div>
+          <ol class="md-search-result__list"></ol>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+      </div>
+
+      <!-- Repository containing source -->
+
+        <div class="md-flex__cell md-flex__cell--shrink">
+          <div class="md-header-nav__source">
+
+
+
+
+
+<a href="https://github.com/BlueBrain/sphinx-bluebrain-theme/" title="Go to repository" class="md-source" data-md-source="github">
+
+    <div class="md-source__icon">
+      <svg viewBox="0 0 24 24" width="24" height="24">
+        <use xlink:href="#__github" width="24" height="24"></use>
+      </svg>
+    </div>
+
+  <div class="md-source__repository">
+    BlueBrain/sphinx-bluebrain-theme
+  </div>
+</a>
+          </div>
+        </div>
+
+    </div>
+  </nav>
+</header>
+
+    <div class="md-container">
+
+
+
+
+      <main class="md-main" role="main">
+        <div class="md-main__inner md-grid" data-md-component="container">
+
+
+              <div class="md-sidebar md-sidebar--primary" data-md-component="navigation">
+                <div class="md-sidebar__scrollwrap">
+                  <div class="md-sidebar__inner">
+                    <nav class="md-nav md-nav--primary" data-md-level="0">
+  <label class="md-nav__title md-nav__title--site" for="__drawer">
+    <a href="https://www.epfl.ch/" title="Sphinx BlueBrain Theme" class="md-nav__button md-logo">
+
+        <img src="_static/images/epfl-logo-new.svg" width="48" height="48">
+
+    </a>
+    Sphinx BlueBrain Theme
+  </label>
+
+    <div class="md-nav__source">
+
+
+
+
+
+<a href="https://github.com/BlueBrain/sphinx-bluebrain-theme/" title="Go to repository" class="md-source" data-md-source="github">
+
+    <div class="md-source__icon">
+      <svg viewBox="0 0 24 24" width="24" height="24">
+        <use xlink:href="#__github" width="24" height="24"></use>
+      </svg>
+    </div>
+
+  <div class="md-source__repository">
+    BlueBrain/sphinx-bluebrain-theme
+  </div>
+</a>
+    </div>
+
+  <ul class="md-nav__list" data-md-scrollfix>
+
+
+
+
+
+
+  <li class="md-nav__item">
+    <a href="index.html" title="Home" class="md-nav__link">
+      Home
+    </a>
+  </li>
+
+
+
+
+
+
+
+  <li class="md-nav__item md-nav__item--nested">
+
+      <input class="md-toggle md-nav__toggle" data-md-toggle="nav-2" type="checkbox" id="nav-2">
+
+    <label class="md-nav__link" for="nav-2">
+      Using the theme
+    </label>
+    <nav class="md-nav" data-md-component="collapsible" data-md-level="1">
+      <label class="md-nav__title" for="nav-2">
+        Using the theme
+      </label>
+      <ul class="md-nav__list" data-md-scrollfix>
+
+
+
+
+
+
+
+  <li class="md-nav__item">
+    <a href="usage.html" title="Guide" class="md-nav__link">
+      Guide
+    </a>
+  </li>
+
+
+
+
+
+
+
+  <li class="md-nav__item">
+    <a href="sample.html" title="Sample" class="md-nav__link">
+      Sample
+    </a>
+  </li>
+
+
+      </ul>
+    </nav>
+  </li>
+
+
+
+
+
+
+
+  <li class="md-nav__item">
+    <a href="changelog.html" title="Changelog" class="md-nav__link">
+      Changelog
+    </a>
+  </li>
+
+
+
+
+
+
+
+  <li class="md-nav__item">
+    <a href="contribute.html" title="Contributing" class="md-nav__link">
+      Contributing
+    </a>
+  </li>
+
+
+
+
+
+
+
+  <li class="md-nav__item md-nav__item--nested">
+
+      <input class="md-toggle md-nav__toggle" data-md-toggle="nav-5" type="checkbox" id="nav-5">
+
+    <label class="md-nav__link" for="nav-5">
+      Theme developers
+    </label>
+    <nav class="md-nav" data-md-component="collapsible" data-md-level="1">
+      <label class="md-nav__title" for="nav-5">
+        Theme developers
+      </label>
+      <ul class="md-nav__list" data-md-scrollfix>
+
+
+
+
+
+
+
+  <li class="md-nav__item">
+    <a href="building.html" title="Building the theme" class="md-nav__link">
+      Building the theme
+    </a>
+  </li>
+
+
+
+
+
+
+
+  <li class="md-nav__item">
+    <a href="overview.html" title="Methodology overview" class="md-nav__link">
+      Methodology overview
+    </a>
+  </li>
+
+
+      </ul>
+    </nav>
+  </li>
+
+
+  </ul>
+</nav>
+                  </div>
+                </div>
+              </div>
+
+
+              <div class="md-sidebar md-sidebar--secondary" data-md-component="toc">
+                <div class="md-sidebar__scrollwrap">
+                  <div class="md-sidebar__inner">
+
+<nav class="md-nav md-nav--secondary">
+
+
+
+    <label class="md-nav__title" for="__toc">Table of contents</label>
+    <ul class="md-nav__list" data-md-scrollfix>
+
+        <li class="md-nav__item">
+  <a href="#second-level-headings" class="md-nav__link">
+    Second level headings
+  </a>
+
+    <nav class="md-nav">
+      <ul class="md-nav__list">
+
+          <li class="md-nav__item">
+  <a href="#third-level-headings" class="md-nav__link">
+    Third level headings
+  </a>
+
+    <nav class="md-nav">
+      <ul class="md-nav__list">
+
+          <li class="md-nav__item">
+  <a href="#fourth-level-headings" class="md-nav__link">
+    Fourth level headings
+  </a>
+
+    <nav class="md-nav">
+      <ul class="md-nav__list">
+
+          <li class="md-nav__item">
+  <a href="#fifth-level-headings" class="md-nav__link">
+    Fifth level headings
+  </a>
+
+    <nav class="md-nav">
+      <ul class="md-nav__list">
+
+          <li class="md-nav__item">
+  <a href="#sixth-level-headings" class="md-nav__link">
+    Sixth level headings
+  </a>
+
+</li>
+
+      </ul>
+    </nav>
+
+</li>
+
+      </ul>
+    </nav>
+
+</li>
+
+      </ul>
+    </nav>
+
+</li>
+
+      </ul>
+    </nav>
+
+</li>
+
+        <li class="md-nav__item">
+  <a href="#lists" class="md-nav__link">
+    Lists
+  </a>
+
+    <nav class="md-nav">
+      <ul class="md-nav__list">
+
+          <li class="md-nav__item">
+  <a href="#unordered-lists" class="md-nav__link">
+    Unordered lists
+  </a>
+
+</li>
+
+          <li class="md-nav__item">
+  <a href="#ordered-lists" class="md-nav__link">
+    Ordered lists
+  </a>
+
+</li>
+
+          <li class="md-nav__item">
+  <a href="#definition-lists" class="md-nav__link">
+    Definition lists
+  </a>
+
+</li>
+
+      </ul>
+    </nav>
+
+</li>
+
+        <li class="md-nav__item">
+  <a href="#code" class="md-nav__link">
+    Code
+  </a>
+
+    <nav class="md-nav">
+      <ul class="md-nav__list">
+
+          <li class="md-nav__item">
+  <a href="#inline-code" class="md-nav__link">
+    Inline code
+  </a>
+
+</li>
+
+          <li class="md-nav__item">
+  <a href="#code-blocks" class="md-nav__link">
+    Code blocks
+  </a>
+
+</li>
+
+          <li class="md-nav__item">
+  <a href="#code-tabs" class="md-nav__link">
+    Code tabs
+  </a>
+
+</li>
+
+      </ul>
+    </nav>
+
+</li>
+
+        <li class="md-nav__item">
+  <a href="#tables" class="md-nav__link">
+    Tables
+  </a>
+
+</li>
+
+        <li class="md-nav__item">
+  <a href="#admonitions" class="md-nav__link">
+    Admonitions
+  </a>
+
+    <nav class="md-nav">
+      <ul class="md-nav__list">
+
+          <li class="md-nav__item">
+  <a href="#built-in-types" class="md-nav__link">
+    Built-in types
+  </a>
+
+</li>
+
+          <li class="md-nav__item">
+  <a href="#additional-types" class="md-nav__link">
+    Additional types
+  </a>
+
+</li>
+
+      </ul>
+    </nav>
+
+</li>
+
+        <li class="md-nav__item">
+  <a href="#miscellaneous" class="md-nav__link">
+    Miscellaneous
+  </a>
+
+    <nav class="md-nav">
+      <ul class="md-nav__list">
+
+          <li class="md-nav__item">
+  <a href="#blockquotes" class="md-nav__link">
+    Blockquotes
+  </a>
+
+    <nav class="md-nav">
+      <ul class="md-nav__list">
+
+          <li class="md-nav__item">
+  <a href="#nested-blockquotes" class="md-nav__link">
+    Nested blockquotes
+  </a>
+
+</li>
+
+      </ul>
+    </nav>
+
+</li>
+
+          <li class="md-nav__item">
+  <a href="#horizontal-rules" class="md-nav__link">
+    Horizontal rules
+  </a>
+
+</li>
+
+          <li class="md-nav__item">
+  <a href="#epigraphs" class="md-nav__link">
+    Epigraphs
+  </a>
+
+</li>
+
+          <li class="md-nav__item">
+  <a href="#topics" class="md-nav__link">
+    Topics
+  </a>
+
+</li>
+
+          <li class="md-nav__item">
+  <a href="#sidebars" class="md-nav__link">
+    Sidebars
+  </a>
+
+</li>
+
+          <li class="md-nav__item">
+  <a href="#collapsible-blocks" class="md-nav__link">
+    Collapsible blocks
+  </a>
+
+</li>
+
+          <li class="md-nav__item">
+  <a href="#iframes" class="md-nav__link">
+    IFrames
+  </a>
+
+</li>
+
+          <li class="md-nav__item">
+  <a href="#images" class="md-nav__link">
+    Images
+  </a>
+
+</li>
+
+      </ul>
+    </nav>
+
+</li>
+
+
+
+
+
+    </ul>
+
+</nav>
+                  </div>
+                </div>
+              </div>
+
+
+          <div class="md-content">
+            <article class="md-content__inner md-typeset">
+
+
+
+                <section id="sample">
+<h1>Sample<a class="headerlink" href="#sample" title="Permalink to this heading">¶</a></h1>
+<p>This page includes samples of the expected output of the theme as well as
+the input used to generate it.</p>
+<section id="second-level-headings">
+<h2>Second level headings<a class="headerlink" href="#second-level-headings" title="Permalink to this heading">¶</a></h2>
+<p>Second level heading section content.</p>
+<section id="third-level-headings">
+<h3>Third level headings<a class="headerlink" href="#third-level-headings" title="Permalink to this heading">¶</a></h3>
+<p>Third level heading section content.</p>
+<section id="fourth-level-headings">
+<h4>Fourth level headings<a class="headerlink" href="#fourth-level-headings" title="Permalink to this heading">¶</a></h4>
+<p>Fourth level heading section content.</p>
+<section id="fifth-level-headings">
+<h5>Fifth level headings<a class="headerlink" href="#fifth-level-headings" title="Permalink to this heading">¶</a></h5>
+<p>Fifth level heading section content.</p>
+<section id="sixth-level-headings">
+<h6>Sixth level headings<a class="headerlink" href="#sixth-level-headings" title="Permalink to this heading">¶</a></h6>
+<p>Sixth level heading section content.</p>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Sample</span>
+<span class="gh">======</span>
+
+This page includes samples of the expected output of the theme as well as
+the input used to generate it.
+
+<span class="gh">Second level headings</span>
+<span class="gh">---------------------</span>
+
+Second level heading section content.
+
+<span class="gh">Third level headings</span>
+<span class="gh">~~~~~~~~~~~~~~~~~~~~</span>
+
+Third level heading section content.
+
+<span class="gh">Fourth level headings</span>
+<span class="gh">*********************</span>
+
+Fourth level heading section content.
+
+<span class="gh">Fifth level headings</span>
+<span class="gh">^^^^^^^^^^^^^^^^^^^^</span>
+
+Fifth level heading section content.
+
+<span class="gh">Sixth level headings</span>
+<span class="gh">++++++++++++++++++++</span>
+
+Sixth level heading section content.
+</pre></div>
+</div>
+</section>
+</section>
+</section>
+</section>
+</section>
+<section id="lists">
+<h2>Lists<a class="headerlink" href="#lists" title="Permalink to this heading">¶</a></h2>
+<section id="unordered-lists">
+<h3>Unordered lists<a class="headerlink" href="#unordered-lists" title="Permalink to this heading">¶</a></h3>
+<ul class="simple">
+<li><p>list item 1.</p></li>
+<li><p>list item 2.</p>
+<ul>
+<li><p>nested list item 1.</p></li>
+<li><p>nested list item 2.</p>
+<ul>
+<li><p>double nested list item 1.</p></li>
+</ul>
+</li>
+<li><p>nested list item 3.</p></li>
+</ul>
+</li>
+</ul>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Unordered lists</span>
+<span class="gh">~~~~~~~~~~~~~~~</span>
+
+<span class="m">*</span> list item 1.
+<span class="m">*</span> list item 2.
+
+  <span class="m">*</span> nested list item 1.
+  <span class="m">*</span> nested list item 2.
+
+    <span class="m">*</span> double nested list item 1.
+
+  <span class="m">*</span> nested list item 3.
+</pre></div>
+</div>
+</section>
+<section id="ordered-lists">
+<h3>Ordered lists<a class="headerlink" href="#ordered-lists" title="Permalink to this heading">¶</a></h3>
+<ol class="arabic simple">
+<li><p>List item 1.</p></li>
+<li><p>List item 2.</p>
+<ol class="arabic simple">
+<li><p>Nested list item 1.</p></li>
+<li><p>Nested list item 2.</p>
+<ol class="arabic simple">
+<li><p>Double nested list item 1.</p></li>
+</ol>
+</li>
+<li><p>Nested list item 3.</p></li>
+</ol>
+</li>
+</ol>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Ordered lists</span>
+<span class="gh">~~~~~~~~~~~~~</span>
+
+<span class="m">#.</span> List item 1.
+<span class="m">#.</span> List item 2.
+
+   <span class="m">#.</span> Nested list item 1.
+   <span class="m">#.</span> Nested list item 2.
+
+      <span class="m">#.</span> Double nested list item 1.
+
+   <span class="m">#.</span> Nested list item 3.
+</pre></div>
+</div>
+</section>
+<section id="definition-lists">
+<h3>Definition lists<a class="headerlink" href="#definition-lists" title="Permalink to this heading">¶</a></h3>
+<dl class="simple">
+<dt>Definition list item 1</dt><dd><p>Definition text for definition list item 1.</p>
+</dd>
+<dt>Definition list item 2</dt><dd><p>Definition text for definition list item 2.</p>
+</dd>
+</dl>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Definition lists</span>
+<span class="gh">~~~~~~~~~~~~~~~~</span>
+
+Definition list item 1
+   Definition text for definition list item 1.
+
+Definition list item 2
+   Definition text for definition list item 2.
+</pre></div>
+</div>
+</section>
+</section>
+<section id="code">
+<h2>Code<a class="headerlink" href="#code" title="Permalink to this heading">¶</a></h2>
+<section id="inline-code">
+<h3>Inline code<a class="headerlink" href="#inline-code" title="Permalink to this heading">¶</a></h3>
+<p>Here is some sample inline code: <code class="code highlight py3 python3 docutils literal highlight-python3"><span class="k">if</span> <span class="n">test</span><span class="p">:</span> <span class="k">return</span> <span class="kc">True</span></code>.</p>
+<div class="admonition attention">
+<p class="admonition-title">Attention</p>
+<p>If you need inline syntax highlighting, you must include a <code class="file docutils literal notranslate"><span class="pre">docutils.conf</span></code>
+file in the same directory as your <code class="file docutils literal notranslate"><span class="pre">conf.py</span></code> file.</p>
+<p>The required content of the file is shown below (see <a class="reference external" href="https://stackoverflow.com/a/48655335">https://stackoverflow.com/a/48655335</a>):</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="p">[</span><span class="n">restructuredtext</span> <span class="n">parser</span><span class="p">]</span>
+<span class="n">syntax_highlight</span> <span class="o">=</span> <span class="n">short</span>
+</pre></div>
+</div>
+</div>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Inline code</span>
+<span class="gh">~~~~~~~~~~~</span>
+
+<span class="p">..</span> <span class="ow">role</span><span class="p">::</span> py3(code)
+   <span class="nc">:language:</span> python3
+
+Here is some sample inline code: <span class="na">:py3:</span><span class="nv">`if test: return True`</span>.
+</pre></div>
+</div>
+</section>
+<section id="code-blocks">
+<h3>Code blocks<a class="headerlink" href="#code-blocks" title="Permalink to this heading">¶</a></h3>
+<div class="highlight-python3 notranslate"><div class="highlight"><pre><span></span><span class="linenos">1</span><span class="k">def</span> <span class="nf">double</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
+<span class="hll"><span class="linenos">2</span>   <span class="k">return</span> <span class="mi">2</span> <span class="o">*</span> <span class="n">x</span>
+</span></pre></div>
+</div>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Code blocks</span>
+<span class="gh">~~~~~~~~~~~</span>
+
+<span class="p">..</span> <span class="ow">code-block</span><span class="p">::</span> python3
+   <span class="nc">:linenos:</span>
+   <span class="nc">:emphasize-lines:</span> 2
+
+   def double(x):
+      return 2 * x
+</pre></div>
+</div>
+</section>
+<section id="code-tabs">
+<h3>Code tabs<a class="headerlink" href="#code-tabs" title="Permalink to this heading">¶</a></h3>
+<p>Tabs can be used to show multiple examples without excessive space. The code
+can be entered directly or included from a file.</p>
+<div class="superfences-tabs docutils container">
+<input checked="checked" id="__tab_1_1" name="__tab_1" type="radio"></input><label for="__tab_1_1">Python</label><div class="superfences-content docutils container">
+<div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">sys</span>
+</pre></div>
+</div>
+</div>
+<input id="__tab_1_2" name="__tab_1" type="radio"></input><label for="__tab_1_2">Ruby</label><div class="superfences-content docutils container">
+<div class="highlight-ruby notranslate"><div class="highlight"><pre><span></span><span class="nb">require</span><span class="w"> </span><span class="n">sys</span>
+</pre></div>
+</div>
+</div>
+<input id="__tab_1_3" name="__tab_1" type="radio"></input><label for="__tab_1_3">From file</label><div class="superfences-content docutils container">
+<div class="highlight-python3 notranslate"><div class="highlight"><pre><span></span><span class="sd">&quot;&quot;&quot;This is a sample for the documentation.&quot;&quot;&quot;</span>
+
+
+<span class="k">def</span> <span class="nf">double</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
+    <span class="k">return</span> <span class="mf">2.0</span> <span class="o">*</span> <span class="n">x</span>
+
+
+<span class="k">def</span> <span class="nf">halve</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
+    <span class="k">return</span> <span class="mf">0.5</span> <span class="o">*</span> <span class="n">x</span>
+
+
+<span class="k">def</span> <span class="nf">list_of_three</span><span class="p">(</span><span class="n">x</span><span class="p">):</span>
+    <span class="k">return</span> <span class="p">[</span><span class="n">x</span><span class="p">]</span> <span class="o">*</span> <span class="mi">3</span>
+</pre></div>
+</div>
+</div>
+</div>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Code tabs</span>
+<span class="gh">~~~~~~~~~</span>
+
+Tabs can be used to show multiple examples without excessive space. The code
+can be entered directly or included from a file.
+
+<span class="p">..</span> <span class="ow">tabgroup</span><span class="p">::</span>
+
+<span class="p">   ..</span> <span class="ow">codetab</span><span class="p">::</span> python Python
+
+       import sys
+
+<span class="p">   ..</span> <span class="ow">codetab</span><span class="p">::</span> ruby Ruby
+
+       require sys
+
+<span class="p">   ..</span> <span class="ow">literaltab</span><span class="p">::</span> sample.py From file
+      <span class="nc">:language:</span> python3
+</pre></div>
+</div>
+</section>
+</section>
+<section id="tables">
+<h2>Tables<a class="headerlink" href="#tables" title="Permalink to this heading">¶</a></h2>
+<table class="docutils align-default">
+<thead>
+<tr class="row-odd"><th class="head"><p>Table header column 1</p></th>
+<th class="head"><p>Column 2</p></th>
+<th class="head"><p>Column 3</p></th>
+<th class="head"><p>Col. 4</p></th>
+<th class="head"><p>C5</p></th>
+<th class="head"><p>C6</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="row-even"><td><p>Row 1 data</p></td>
+<td><p>1.0</p></td>
+<td><p>0.1234</p></td>
+<td><p>0.001</p></td>
+<td><p>10.0</p></td>
+<td><p>-1</p></td>
+</tr>
+<tr class="row-odd"><td><p>Row 2 data</p></td>
+<td><p>1000.0</p></td>
+<td><p>-1.2345</p></td>
+<td><p>5.01</p></td>
+<td><p>-</p></td>
+<td><p>-</p></td>
+</tr>
+</tbody>
+</table>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Tables</span>
+<span class="gh">------</span>
+
+<span class="p">..</span> <span class="ow">table</span><span class="p">::</span>
+
+   ======================== =========== ========== ======= ==== ===
+   Table header column 1    Column 2    Column 3   Col. 4  C5   C6
+   ======================== =========== ========== ======= ==== ===
+   Row 1 data               1.0         0.1234     0.001   10.0 -1
+   Row 2 data               1000.0      -1.2345    5.01    \-   \-
+   ======================== =========== ========== ======= ==== ===
+</pre></div>
+</div>
+</section>
+<section id="admonitions">
+<h2>Admonitions<a class="headerlink" href="#admonitions" title="Permalink to this heading">¶</a></h2>
+<section id="built-in-types">
+<h3>Built-in types<a class="headerlink" href="#built-in-types" title="Permalink to this heading">¶</a></h3>
+<div class="admonition attention">
+<p class="admonition-title">Attention</p>
+<p>Attention</p>
+</div>
+<div class="admonition caution">
+<p class="admonition-title">Caution</p>
+<p>Caution</p>
+</div>
+<div class="admonition danger">
+<p class="admonition-title">Danger</p>
+<p>Danger</p>
+</div>
+<div class="admonition error">
+<p class="admonition-title">Error</p>
+<p>Error</p>
+</div>
+<div class="admonition hint">
+<p class="admonition-title">Hint</p>
+<p>Hint</p>
+</div>
+<div class="admonition important">
+<p class="admonition-title">Important</p>
+<p>Important</p>
+</div>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>Note</p>
+</div>
+<div class="admonition tip">
+<p class="admonition-title">Tip</p>
+<p>Tip</p>
+</div>
+<div class="admonition warning">
+<p class="admonition-title">Warning</p>
+<p>Warning</p>
+</div>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Built-in types</span>
+<span class="gh">~~~~~~~~~~~~~~</span>
+
+<span class="p">..</span> <span class="ow">attention</span><span class="p">::</span>
+
+   Attention
+
+<span class="p">..</span> <span class="ow">caution</span><span class="p">::</span>
+
+   Caution
+
+<span class="p">..</span> <span class="ow">danger</span><span class="p">::</span>
+
+   Danger
+
+<span class="p">..</span> <span class="ow">error</span><span class="p">::</span>
+
+   Error
+
+<span class="p">..</span> <span class="ow">hint</span><span class="p">::</span>
+
+   Hint
+
+<span class="p">..</span> <span class="ow">important</span><span class="p">::</span>
+
+   Important
+
+<span class="p">..</span> <span class="ow">note</span><span class="p">::</span>
+
+   Note
+
+<span class="p">..</span> <span class="ow">tip</span><span class="p">::</span>
+
+   Tip
+
+<span class="p">..</span> <span class="ow">warning</span><span class="p">::</span>
+
+   Warning
+</pre></div>
+</div>
+</section>
+<section id="additional-types">
+<h3>Additional types<a class="headerlink" href="#additional-types" title="Permalink to this heading">¶</a></h3>
+<p>These types require you to add the class explicitly using <code class="docutils literal notranslate"><span class="pre">:class:</span> <span class="pre">classname</span></code>.
+Applicable classnames are shown in each admonition.</p>
+<div class="abstract admonition">
+<p class="admonition-title">Abstract</p>
+<ul class="simple">
+<li><p>abstract</p></li>
+<li><p>summary</p></li>
+<li><p>tldr</p></li>
+</ul>
+</div>
+<div class="info admonition">
+<p class="admonition-title">Info</p>
+<ul class="simple">
+<li><p>info</p></li>
+<li><p>todo</p></li>
+</ul>
+</div>
+<div class="success admonition">
+<p class="admonition-title">Success</p>
+<ul class="simple">
+<li><p>success</p></li>
+<li><p>check</p></li>
+<li><p>done</p></li>
+</ul>
+</div>
+<div class="question admonition">
+<p class="admonition-title">Question</p>
+<ul class="simple">
+<li><p>question</p></li>
+<li><p>help</p></li>
+<li><p>faq</p></li>
+</ul>
+</div>
+<div class="failure admonition">
+<p class="admonition-title">Failure</p>
+<ul class="simple">
+<li><p>failure</p></li>
+<li><p>fail</p></li>
+<li><p>missing</p></li>
+</ul>
+</div>
+<div class="bug admonition">
+<p class="admonition-title">Bug</p>
+<ul class="simple">
+<li><p>bug</p></li>
+</ul>
+</div>
+<div class="example admonition">
+<p class="admonition-title">Example</p>
+<ul class="simple">
+<li><p>example</p></li>
+<li><p>snippet</p></li>
+</ul>
+</div>
+<div class="quote admonition">
+<p class="admonition-title">Quote</p>
+<ul class="simple">
+<li><p>quote</p></li>
+<li><p>cite</p></li>
+</ul>
+</div>
+<div class="deprecated admonition">
+<p class="admonition-title">Deprecated</p>
+<ul class="simple">
+<li><p>deprecated</p></li>
+<li><p>archived</p></li>
+</ul>
+</div>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Additional types</span>
+<span class="gh">~~~~~~~~~~~~~~~~</span>
+
+These types require you to add the class explicitly using <span class="s">``:class: classname``</span>.
+Applicable classnames are shown in each admonition.
+
+<span class="p">..</span> <span class="ow">admonition</span><span class="p">::</span> Abstract
+   <span class="nc">:class:</span> abstract
+
+   <span class="m">-</span> abstract
+   <span class="m">-</span> summary
+   <span class="m">-</span> tldr
+
+<span class="p">..</span> <span class="ow">admonition</span><span class="p">::</span> Info
+   <span class="nc">:class:</span> info
+
+   <span class="m">-</span> info
+   <span class="m">-</span> todo
+
+<span class="p">..</span> <span class="ow">admonition</span><span class="p">::</span> Success
+   <span class="nc">:class:</span> success
+
+   <span class="m">-</span> success
+   <span class="m">-</span> check
+   <span class="m">-</span> done
+
+<span class="p">..</span> <span class="ow">admonition</span><span class="p">::</span> Question
+   <span class="nc">:class:</span> question
+
+   <span class="m">-</span> question
+   <span class="m">-</span> help
+   <span class="m">-</span> faq
+
+<span class="p">..</span> <span class="ow">admonition</span><span class="p">::</span> Failure
+   <span class="nc">:class:</span> failure
+
+   <span class="m">-</span> failure
+   <span class="m">-</span> fail
+   <span class="m">-</span> missing
+
+<span class="p">..</span> <span class="ow">admonition</span><span class="p">::</span> Bug
+   <span class="nc">:class:</span> bug
+
+   <span class="m">-</span> bug
+
+<span class="p">..</span> <span class="ow">admonition</span><span class="p">::</span> Example
+   <span class="nc">:class:</span> example
+
+   <span class="m">-</span> example
+   <span class="m">-</span> snippet
+
+<span class="p">..</span> <span class="ow">admonition</span><span class="p">::</span> Quote
+   <span class="nc">:class:</span> quote
+
+   <span class="m">-</span> quote
+   <span class="m">-</span> cite
+
+<span class="p">..</span> <span class="ow">admonition</span><span class="p">::</span> Deprecated
+   <span class="nc">:class:</span> deprecated
+
+   <span class="m">-</span> deprecated
+   <span class="m">-</span> archived
+</pre></div>
+</div>
+</section>
+</section>
+<section id="miscellaneous">
+<h2>Miscellaneous<a class="headerlink" href="#miscellaneous" title="Permalink to this heading">¶</a></h2>
+<section id="blockquotes">
+<h3>Blockquotes<a class="headerlink" href="#blockquotes" title="Permalink to this heading">¶</a></h3>
+<blockquote>
+<div><p>Blockquote content.</p>
+</div></blockquote>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Blockquotes</span>
+<span class="gh">~~~~~~~~~~~</span>
+
+   Blockquote content.
+</pre></div>
+</div>
+<section id="nested-blockquotes">
+<h4>Nested blockquotes<a class="headerlink" href="#nested-blockquotes" title="Permalink to this heading">¶</a></h4>
+<blockquote>
+<div><p>Blockquote content.</p>
+<blockquote>
+<div><p>Nested blockquote content.</p>
+<blockquote>
+<div><p>Double nested blockquote content.</p>
+</div></blockquote>
+</div></blockquote>
+</div></blockquote>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Nested blockquotes</span>
+<span class="gh">******************</span>
+
+   Blockquote content.
+
+      Nested blockquote content.
+
+         Double nested blockquote content.
+</pre></div>
+</div>
+</section>
+</section>
+<section id="horizontal-rules">
+<h3>Horizontal rules<a class="headerlink" href="#horizontal-rules" title="Permalink to this heading">¶</a></h3>
+<p>Here is some text before a horizontal rule.</p>
+<hr class="docutils" />
+<p>Here is some text after a horizontal rule</p>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Horizontal rules</span>
+<span class="gh">~~~~~~~~~~~~~~~~</span>
+
+Here is some text before a horizontal rule.
+
+----
+
+Here is some text after a horizontal rule
+</pre></div>
+</div>
+</section>
+<section id="epigraphs">
+<h3>Epigraphs<a class="headerlink" href="#epigraphs" title="Permalink to this heading">¶</a></h3>
+<blockquote class="epigraph">
+<div><p>This is an epigraph.</p>
+<p class="attribution">—by an Author</p>
+</div></blockquote>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Epigraphs</span>
+<span class="gh">~~~~~~~~~</span>
+
+<span class="p">..</span> <span class="ow">epigraph</span><span class="p">::</span>
+
+   This is an epigraph.
+
+   -- by an Author
+</pre></div>
+</div>
+</section>
+<section id="topics">
+<h3>Topics<a class="headerlink" href="#topics" title="Permalink to this heading">¶</a></h3>
+<aside class="topic">
+<p class="topic-title">Topic title</p>
+<p>This is a topic</p>
+</aside>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Topics</span>
+<span class="gh">~~~~~~</span>
+
+<span class="p">..</span> <span class="ow">topic</span><span class="p">::</span> Topic title
+
+   This is a topic
+</pre></div>
+</div>
+</section>
+<section id="sidebars">
+<h3>Sidebars<a class="headerlink" href="#sidebars" title="Permalink to this heading">¶</a></h3>
+<aside class="admonition sidebar">
+<p class="sidebar-title">Sidebar title</p>
+<p>This is a sidebar</p>
+</aside>
+<p>Here is some text that will flow around the sidebar that follows.
+If we have something interesting to say, we can put it in the
+sidebar.</p>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Sidebars</span>
+<span class="gh">~~~~~~~~</span>
+
+<span class="p">..</span> <span class="ow">sidebar</span><span class="p">::</span> Sidebar title
+   <span class="nc">:class:</span> admonition
+
+   This is a sidebar
+
+Here is some text that will flow around the sidebar that follows.
+If we have something interesting to say, we can put it in the
+sidebar.
+</pre></div>
+</div>
+</section>
+<section id="collapsible-blocks">
+<h3>Collapsible blocks<a class="headerlink" href="#collapsible-blocks" title="Permalink to this heading">¶</a></h3>
+<details>
+<summary>Details hidden by default</summary><p>Here is some content that is hidden before opening.</p>
+</details><details open="">
+<summary>Details shown by default</summary><p>Here is some content that is shown by default</p>
+</details><div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Collapsible blocks</span>
+<span class="gh">~~~~~~~~~~~~~~~~~~</span>
+
+<span class="p">..</span> <span class="ow">details</span><span class="p">::</span> Details hidden by default
+
+   Here is some content that is hidden before opening.
+
+<span class="p">..</span> <span class="ow">details</span><span class="p">::</span> Details shown by default
+   <span class="nc">:open:</span>
+
+   Here is some content that is shown by default
+</pre></div>
+</div>
+</section>
+<section id="iframes">
+<h3>IFrames<a class="headerlink" href="#iframes" title="Permalink to this heading">¶</a></h3>
+<p>Embed existing HTML files (such as Doxygen output) in generated pages.</p>
+<iframe class="sphinx-iframe" scrolling="no" src="index.html">
+</iframe><div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">IFrames</span>
+<span class="gh">~~~~~~~</span>
+
+Embed existing HTML files (such as Doxygen output) in generated pages.
+
+<span class="p">..</span> <span class="ow">iframe</span><span class="p">::</span> index.html
+</pre></div>
+</div>
+</section>
+<section id="images">
+<h3>Images<a class="headerlink" href="#images" title="Permalink to this heading">¶</a></h3>
+<p>Embed an image with optional alignment.</p>
+<a class="reference internal image-reference" href="_images/epfl-logo-new.svg"><img alt="_images/epfl-logo-new.svg" class="align-left" src="_images/epfl-logo-new.svg" width="25%" /></a>
+<a class="reference internal image-reference" href="_images/epfl-logo-new.svg"><img alt="_images/epfl-logo-new.svg" class="align-center" src="_images/epfl-logo-new.svg" width="25%" /></a>
+<a class="reference internal image-reference" href="_images/epfl-logo-new.svg"><img alt="_images/epfl-logo-new.svg" class="align-right" src="_images/epfl-logo-new.svg" width="25%" /></a>
+<div class="highlight-rst notranslate"><div class="highlight"><pre><span></span><span class="gh">Images</span>
+<span class="gh">~~~~~~</span>
+
+Embed an image with optional alignment.
+
+<span class="p">..</span> <span class="ow">image</span><span class="p">::</span> _images/epfl-logo-new.svg
+   <span class="nc">:width:</span> 25%
+   <span class="nc">:align:</span> left
+
+<span class="p">..</span> <span class="ow">image</span><span class="p">::</span> _images/epfl-logo-new.svg
+   <span class="nc">:width:</span> 25%
+   <span class="nc">:align:</span> center
+
+<span class="p">..</span> <span class="ow">image</span><span class="p">::</span> _images/epfl-logo-new.svg
+   <span class="nc">:width:</span> 25%
+   <span class="nc">:align:</span> right
+</pre></div>
+</div>
+</section>
+</section>
+</section>
+
+
+
+    <h2 id="__source">Source</h2>
+    <a href="_sources/regression.rst.txt" title="regression.rst" class="md-source-file">
+      regression.rst
+    </a>
+
+
+
+
+            </article>
+          </div>
+        </div>
+      </main>
+
+
+
+
+
+<!-- Application footer -->
+<footer class="md-footer">
+
+  <!-- Link to previous and/or next page -->
+
+
+  <!-- Further information -->
+  <div class="md-footer-meta md-typeset">
+    <div class="md-footer-meta__inner md-grid">
+
+      <!-- Copyright and theme information -->
+      <div class="md-footer-copyright">
+
+
+
+          <div class="md-footer-copyright__company">
+            Blue Brain Project
+          </div>
+
+
+          <div class="md-footer-copyright__address__title">
+            Address
+          </div>
+          <div class="md-footer-copyright__address">
+            EPFL/Campus Biotech<br>Chemin des Mines 9,<br>CH-1202 Geneva<br>Switzerland
+          </div>
+
+
+
+          <div class="md-footer-copyright__highlight">
+            &copy; Blue Brain Project/EPFL 2005-2024. All rights reserved.
+          </div>
+
+
+      </div>
+
+
+      <!-- Social links -->
+
+
+<!-- Social links in footer -->
+
+  <div class="md-footer-social">
+    <link rel="stylesheet" type="text/css"
+        href="_static/fonts/font-awesome.css" />
+
+
+    <div class="md-footer-social__title">Follow the Blue Brain</div>
+
+
+
+      <a href="https://www.linkedin.com/showcase/blue-brain-project/" class="md-footer-social__link
+            fa fa-linkedin-square"></a>
+
+      <a href="https://twitter.com/bluebrainpjt?lang=en" class="md-footer-social__link
+            fa fa-twitter-square"></a>
+
+  </div>
+
+    </div>
+  </div>
+</footer>
+
+    </div>
+
+    <script data-url_root="./" id="documentation_options" src="_static/documentation_options.js?v=21ccd5af"></script>
+    <script src="_static/doctools.js?v=888ff710"></script>
+    <script src="_static/sphinx_highlight.js?v=1"></script>
+<script src="https://code.jquery.com/jquery-3.6.3.slim.min.js"></script>
+<script src="_static/javascripts/theme.js"></script>
+<script src="_static/javascripts/utils.js"></script>
+
+      <script src="_static/javascripts/application.718059d6.js"></script>
+
+      <script>app.initialize({version:"REGRESSION-TEST",url:{base:"./_static"}})</script>
+
+
+
+  </body>
+</html>

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -100,3 +100,34 @@ def test_get_metadata_from_json():
         # check all values are the same as their keys
         for k, v in md.items():
             assert k == v
+
+
+def test_get_metadata_from_distribution():
+    """Test getting metadata from a distribution.
+
+    The package itself must be installed in the virtualenv.
+    """
+    result = metadata.get_metadata_from_distribution("sphinx-bluebrain-theme")
+    assert set(result) == {
+        "contributors",
+        "description",
+        "homepage",
+        "issuesurl",
+        "license",
+        "maintainers",
+        "name",
+        "repository",
+        "version",
+    }
+    # ignore version and description
+    del result["version"]
+    del result["description"]
+    assert result == {
+        "name": "sphinx-bluebrain-theme",
+        "homepage": "https://github.com/BlueBrain/sphinx-bluebrain-theme",
+        "license": "MIT License",
+        "maintainers": "Blue Brain Project, EPFL",
+        "repository": "https://github.com/BlueBrain/sphinx-bluebrain-theme",
+        "issuesurl": "https://github.com/BlueBrain/sphinx-bluebrain-theme/issues",
+        "contributors": None,
+    }

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ envlist =
     lint
     docs
     check-packaging
-    py{38,39,310,311}
+    py{38,39,310,311,312}
 
 [testenv]
 # we skip the install initially so as to build an up-to-date version
@@ -89,3 +89,4 @@ python =
   3.9: py39
   3.10: py310
   3.11: py311, lint, docs, check-packaging
+  3.12: py312


### PR DESCRIPTION
- Add tests for Python 3.12
- Replace pkg_resources (deprecated, and needing setuptools as explicit requirement in python 3.12) with importlib
- Fix ``regression.html`` with sphinx 7.2 (keep regression_sphinx_7.1.html for python 3.8 and sphinx 7.1)
