### PR TITLE
Use summary to set metadata description

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.4.4
+-----
+- |fixed| Use summary to set metadata description
+
 0.4.3
 -----
 - |added| Add tests for Python 3.12

--- a/src/utils/metadata.py
+++ b/src/utils/metadata.py
@@ -112,7 +112,7 @@ def build_metadata_from_setuptools_dict(metadata):
     output = {
         "name": metadata["name"],
         "version": metadata["version"],
-        "description": metadata["description"],
+        "description": metadata["summary"],
         "homepage": homepage_url,
         "license": metadata["license"],
         "maintainers": author,
@@ -145,10 +145,6 @@ def get_metadata_from_distribution(distribution_name):
         elif isinstance(value, list):
             key = f"{key}s"
         metadata[key] = value
-
-    # allow summary as the description
-    if "description" not in metadata:
-        metadata["description"] = metadata["summary"]
 
     # home-page needs to be used for the url
     if "home_page" in metadata:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -119,7 +119,7 @@ def test_get_metadata_from_distribution():
         "repository",
         "version",
     }
-    # ignore version because not fixed
+    # ignore version because it can change
     del result["version"]
     assert result == {
         "name": "sphinx-bluebrain-theme",

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -119,11 +119,11 @@ def test_get_metadata_from_distribution():
         "repository",
         "version",
     }
-    # ignore version and description
+    # ignore version because not fixed
     del result["version"]
-    del result["description"]
     assert result == {
         "name": "sphinx-bluebrain-theme",
+        "description": "Blue Brain Project theme for Sphinx",
         "homepage": "https://github.com/BlueBrain/sphinx-bluebrain-theme",
         "license": "MIT License",
         "maintainers": "Blue Brain Project, EPFL",


### PR DESCRIPTION
From https://packaging.python.org/en/latest/specifications/core-metadata/
- Summary: A one-line summary of what the distribution does.
- Description: A longer description of the distribution that can run to several paragraphs

https://packaging.python.org/en/latest/specifications/pyproject-toml/#description
Corresponding core metadata field: Summary

https://packaging.python.org/en/latest/specifications/pyproject-toml/#readme
Corresponding core metadata field: Description and Description-Content-Type

So we should export `summary`, because `docs-internal-upload` cannot handle multilines in `metadata.md`.